### PR TITLE
Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "guzzlehttp/guzzle": "^6.2||^7.0",
         "divineomega/do-file-cache": "^2.0",
         "divineomega/php-distance": "^1.0",
-        "laravel/framework": "^5.1||^6.0||^7.0||^8.0",
+        "laravel/framework": "^5.1||^6.0||^7.0||^8.0||^9.0",
         "ext-json": "*",
         "php": ">=7.0"
     },


### PR DESCRIPTION
This PR modifies composer to allow installation of PHP Simple Google Maps on Laravel 9.